### PR TITLE
Re-request quote if response is slow

### DIFF
--- a/broadcastHandler.go
+++ b/broadcastHandler.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
 	"fmt"
-	"io"
 	"net"
 	"time"
 
@@ -70,25 +69,69 @@ func getNewQuote(qr types.QuoteRequest) types.Quote {
 		config.QuoteServer.Host, config.QuoteServer.Port,
 	)
 
-	quoteServerConn, err := net.DialTimeout("tcp", quoteServerAddress, time.Second*5)
-	failOnError(err, "Could not connect to "+quoteServerAddress)
-	defer quoteServerConn.Close()
-
 	// quoteserve.seng reads until it sees a \n
 	quoteServerMessage := fmt.Sprintf("%s,%s\n", qr.Stock, qr.UserID)
-	quoteServerConn.Write([]byte(quoteServerMessage))
-	// TODO: retry on timeout?
 
-	response, err := bufio.NewReader(quoteServerConn).ReadString('\n')
-	// when stream is done an EOF is emitted that we should ignore
-	if err != io.EOF && err != nil {
-		// TODO: retry on timeout?
-		failOnError(err, "Failed to read quote server response")
+	readTimeoutBase := time.Millisecond * time.Duration(config.QuoteServer.Retry)
+	backoff := time.Millisecond * time.Duration(config.QuoteServer.Backoff)
+
+	respBuf := make([]byte, 1024)
+	attempts := 1
+
+	// Loop until read completes or deadline arrives. Do exponential backoff
+	// if we time out.
+	for {
+		consoleLog.Debug("Attempt", attempts)
+
+		// Get a new connection
+		quoteServerConn, err := net.DialTimeout("tcp", quoteServerAddress, time.Second*5)
+		failOnError(err, "Could not connect to "+quoteServerAddress)
+
+		// Send the message
+		quoteServerConn.Write([]byte(quoteServerMessage))
+
+		// Set the deadline
+		timeout := readTimeoutBase + backoff
+		quoteServerConn.SetReadDeadline(time.Now().Add(timeout))
+
+		// Wait for read or timeout
+		_, err = quoteServerConn.Read(respBuf)
+
+		// We either read successfuly or we need to backoff and make
+		// a new connection.
+		quoteServerConn.Close()
+
+		// If everything was okay then we got a response
+		if err == nil {
+			// Exit the loop
+			break
+		}
+
+		// Don't back off forever. Max delay from quote server is 4s.
+		// Fail if we waited > 5s so we can investigate.
+		if timeout > time.Second*5 {
+			consoleLog.Fatalf("No response from %s after %d ms", quoteServerAddress, timeout/1e6)
+		}
+
+		// check for a timeout
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			// do the backoff and try again
+			backoff *= 2
+			consoleLog.Debugf("Attempt %d timeout. Waiting for %d ms", attempts, timeout/1e6)
+		} else {
+			failOnError(err, "Failed to read from quoteserver")
+		}
+
+		attempts++
 	}
 
-	// Append the quote request transaction ID to the quote
-	response = fmt.Sprintf("%s,%d", response, qr.ID)
-	quote, err := types.ParseQuote(response)
+	// clean up the unused space in the buffer
+	respBuf = bytes.Trim(respBuf, "\x00")
+
+	// Append the quote request transaction ID to the quote so the ID
+	// will be associated with the object when it's parsed.
+	respWithTxID := fmt.Sprintf("%s,%d", string(respBuf), qr.ID)
+	quote, err := types.ParseQuote(respWithTxID)
 	failOnError(err, "Could not parse quote response")
 
 	return quote

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -7,6 +7,8 @@ rabbit:
 quote server:
   host: "localhost"
   port: 4443
+  retry: 150 # milliseconds
+  backoff: 10 # milliseconds
 
 redis:
   host: "localhost"

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -8,7 +8,7 @@ quote server:
   host: "localhost"
   port: 4443
   retry: 150 # milliseconds
-  backoff: 10 # milliseconds
+  backoff: 5 # milliseconds
 
 redis:
   host: "localhost"

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -8,7 +8,7 @@ quote server:
   host: "quoteserve.seng.uvic.ca"
   port: 4443
   retry: 150
-  backoff: 10
+  backoff: 5
 
 redis:
   host: "localhost"

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -7,6 +7,8 @@ rabbit:
 quote server:
   host: "quoteserve.seng.uvic.ca"
   port: 4443
+  retry: 150
+  backoff: 10
 
 redis:
   host: "localhost"

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -9,3 +9,13 @@ if [ $? -ne 0 ]; then
 else
   echo "✔ Linter passed"
 fi
+
+# Check for files with formatting different from gofmt's
+gofmt -l .
+
+if [ $? -ne 0 ]; then
+  echo "✗ gofmt failed. Branch not pushed to remote."
+  exit 1
+else
+  echo "✔ gofmt passed"
+fi

--- a/main.go
+++ b/main.go
@@ -105,8 +105,10 @@ var config struct {
 	}
 
 	QuoteServer struct {
-		Host string
-		Port int
+		Host    string
+		Port    int
+		Retry   int
+		Backoff int
 	} `yaml:"quote server"`
 
 	Redis struct {


### PR DESCRIPTION
Results from the [quote server response experiment][experiment] indicate that:
1. Delays are integers, 0->4sec
1. Network delays are ~100ms so the server response delay dominates.
1. The mean delay is < 1sec.

![hist](https://cloud.githubusercontent.com/assets/6734837/23334118/33848b54-fb4d-11e6-99fe-d38117c1ee2e.png)

This means that if we don't get a response from the server after ~150ms then we'll have to wait at least 1sec, which is larger than the mean. The optimal strategy (fewest unnecessary retries, lowest time waiting) for retrieving a quote is to re-request after 150ms.

This PR implements the above retry logic. If the we don't get a response after 150ms when we do exponential (base 2) backoff of 10ms up to a max of 5sec. This avoids flooding the network with traffic and guarantees that the request loop terminates. I chose 10ms as a default backoff so we approach the mean response time slowly (needs 6 attempts to wait longer than mean).

I replaced `bufio.Reader` with `net.Read` since the former doesn't allow a timeout.

#### Bonus!
I add `gofmt` to the CI check. This matches the process that `worker` uses.

[experiment]: https://github.com/DistributedDesigns/docs/tree/master/data/quoteserver-times