### PR TITLE
Fix quote TTLs

### DIFF
--- a/broadcastHandler.go
+++ b/broadcastHandler.go
@@ -91,5 +91,13 @@ func getNewQuote(qr types.QuoteRequest) types.Quote {
 	quote, err := types.ParseQuote(response)
 	failOnError(err, "Could not parse quote response")
 
+	// ParseQuote expects the timestamp to be passed as seconds but the
+	// quoteserver timestamp is in milliseconds. Hence, the quote we just
+	// created has the wrong time. We need to convert its time down
+	// to seconds and preserve its accuracy.
+	seconds := quote.Timestamp.Unix() / 1e3
+	nano := (quote.Timestamp.UnixNano() / 1e3) % 1e9
+	quote.Timestamp = time.Unix(seconds, nano)
+
 	return quote
 }


### PR DESCRIPTION
The actual quoteserver sends quote timestamps as milliseconds. When we parse this as a `Quote` we parse the time as seconds. It looks like the quote is created at some point really far into the future! This means that the cache TTL is super big and it never expires.

This PR handles quote responses with timestamps in ms by creating a `Quote` with the wrong time and then scaling it back. Not ideal, but the alternative to 1. refactor `ParseQuote` to accept second or ms timestamps (through a parameter?), or 2. alter the response we get back from the service before it's parsed. I don't like overloading `ParseQuote` and mucking around in `byte[]` is something I'd like to avoid so here we go!.

#### Note
Update the [fake quote server](https://github.com/DistributedDesigns/fake_quote_server/commit/5b98ae1ad2a0304ff9cdf2421dd7a0b930eb8a54) so it generates quotes with ms timestamps and reproduces the error from prod.

### Logs
Before fix:
```
now:	1488056317
quote:	1488056317307
ttl:	1486568261048
```

After fix:
```
now:	1488057322760165868
quote:	1488057322789526320
ttl:	59
```