### PR TITLE
Only ACK quote request after broadcast

### DIFF
--- a/broadcastHandler.go
+++ b/broadcastHandler.go
@@ -61,6 +61,8 @@ func retrieveAndPublishQuote(req amqp.Delivery) {
 		})
 	failOnError(err, "Failed to publish a message")
 
+	req.Ack(false)
+
 	consoleLog.Infof(" [↑] Broadcast: TxID %d %s %s", quote.ID, quote.Stock, quote.Price.String())
 }
 

--- a/requestHandler.go
+++ b/requestHandler.go
@@ -26,7 +26,7 @@ func handleQuoteRequest() {
 			consoleLog.Infof(" [↓] Request: TxID %s, '%s'", d.CorrelationId, d.Body)
 			consoleLog.Debugf("Headers: %+v", d.Headers)
 			pendingQuoteReqs <- d
-			d.Ack(false)
+			// message ACKed after broadcast
 		}
 	}()
 


### PR DESCRIPTION
Preserves transaction flow in event quote_manager crashes. Crashes are not as uncommon as I'd like because the legacy service times out 😖 