### PR TITLE
Use minimum possible legacy server timeout in prod

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -7,7 +7,7 @@ rabbit:
 quote server:
   host: "quoteserve.seng.uvic.ca"
   port: 4443
-  retry: 150
+  retry: 20
   backoff: 5
 
 redis:


### PR DESCRIPTION
When I initially set the timeout I misread the data and assumed 15ms = 150ms. Oh no!

[Here](https://github.com/DistributedDesigns/docs/blob/master/data/quoteserver-times/analysis.pdf) is the full analysis I did on the data. tl;dr if a quote is coming back with no delay it will almost always arrive before 20ms.

I just used this config in the lab to get the 1000 user file done in <1 min. 17k TPS is in sight 🔥 